### PR TITLE
timings: do not return None when delays are zero but not null

### DIFF
--- a/quicklogic_timings_importer/quicklogic_timings_importer.py
+++ b/quicklogic_timings_importer/quicklogic_timings_importer.py
@@ -90,7 +90,7 @@ class JSONToSDFParser():
         bool: True if empty, else False
         """
         for val in delval.values():
-            if not(val is None or float(val) == 0):
+            if not(val is None):
                 return False
         return True
 
@@ -418,7 +418,7 @@ class JSONToSDFParser():
                                     elementnametotiming[elname].append(timing)
                                     # add SDF entry
                                     if cls.normalize_cell_names:
-                                        elname = cls.normalize_name(elname)                                    
+                                        elname = cls.normalize_name(elname)
                                     cells[cname][instancename][elname] = element
 
         # generate SDF file from dictionaries


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

Some liberty files do include zero-valued delays. These should still appear in the SDF timings, but currently they are truncated if they are equal to 0.

This PR allows zero-valued delays to be exported in the SDF timing files